### PR TITLE
Fix unit update ID not passing to backend

### DIFF
--- a/src/pages/Admin Properties/Units/Edit Unit Modal/EditUnitModal.jsx
+++ b/src/pages/Admin Properties/Units/Edit Unit Modal/EditUnitModal.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./editunitmodal.css";
 import UnitFormFlow from "./Unit Form Flow/UnitFormFlow";
 
-const EditUnitModal = ({ open, onClose, title }) => {
+const EditUnitModal = ({ open, onClose, title ,unitId}) => {
   return (
     <div
       onClick={onClose}
@@ -15,7 +15,7 @@ const EditUnitModal = ({ open, onClose, title }) => {
                     ${open ? "scale-100 opacity-100" : "scale-125 opacity-0"}`}
       >
         {/* Content Here */}
-        <UnitFormFlow title={title} onClose={onClose} />
+        <UnitFormFlow title={title} onClose={onClose}  unitId={unitId}/>
       </div>
     </div>
   );

--- a/src/pages/Admin Properties/Units/Units.jsx
+++ b/src/pages/Admin Properties/Units/Units.jsx
@@ -82,7 +82,6 @@ const Units = () => {
     console.log("Units: Selected unitId:", unitId);
     setSelectedUnitId(unitId);
     setTimeout(() => {
-      console.log("Units: Opening update modal with unitId:", unitId);
       setUpdateUnitModalOpen(true);
     });
   };

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,1 +1,2 @@
-export const BASE_URL = 'https://rentbiz.hoztox.in';
+// export const BASE_URL = 'https://rentbiz.hoztox.in';
+export const BASE_URL = ' http://127.0.0.1:8000';


### PR DESCRIPTION
Resolved issue where the unit update ID was not being sent to the backend during the update operation. Additionally, fixed an issue where the API was called on initial select without user interaction, ensuring data is only fetched after explicit selection.